### PR TITLE
Upgrade vulcanize-geth to v4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,4 +17,4 @@ require (
 	github.com/vulcanize/go-eth-state-node-iterator v1.0.1
 )
 
-replace github.com/ethereum/go-ethereum v1.10.17 => github.com/vulcanize/go-ethereum v1.10.17-statediff-3.2.0.0.20220512091306-cef1fc425fe4
+replace github.com/ethereum/go-ethereum v1.10.17 => github.com/vulcanize/go-ethereum v1.10.17-statediff-4.0.0-alpha

--- a/go.sum
+++ b/go.sum
@@ -701,8 +701,8 @@ github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPU
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/vulcanize/go-eth-state-node-iterator v1.0.1 h1:lI8+moQ0Nv62NwmiCxgvWkC/Wj46KmDPX1dhBwyqRy8=
 github.com/vulcanize/go-eth-state-node-iterator v1.0.1/go.mod h1:uWhleTvUEZ+cEkNRIAmBpZ14KilTP71OxY5NZDrpNlo=
-github.com/vulcanize/go-ethereum v1.10.17-statediff-3.2.0.0.20220512091306-cef1fc425fe4 h1:ZnpIRq7tSq7u8nYuZfiUX8hNMEVIUkSu02h2omym6wo=
-github.com/vulcanize/go-ethereum v1.10.17-statediff-3.2.0.0.20220512091306-cef1fc425fe4/go.mod h1:mDwZX+QoWdqzQo6SDG3YVqCYACutcSG6uzpziMvTu28=
+github.com/vulcanize/go-ethereum v1.10.17-statediff-4.0.0-alpha h1:QicDxlfQqHfEFW2uRfyNqN5nFaRGuDS4o9Dv4EaLcuA=
+github.com/vulcanize/go-ethereum v1.10.17-statediff-4.0.0-alpha/go.mod h1:mDwZX+QoWdqzQo6SDG3YVqCYACutcSG6uzpziMvTu28=
 github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc h1:9lDbC6Rz4bwmou+oE6Dt4Cb2BGMur5eR/GYptkKUVHo=
 github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc/go.mod h1:bopw91TMyo8J3tvftk8xmU2kPmlrt4nScJQZU2hE5EM=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=


### PR DESCRIPTION
Part of https://github.com/vulcanize/issue_tracking/issues/16

- Upgrade vulcanize-geth to `v1.10.17-statediff-4.0.0-alpha`