### PR TITLE
Encode watched address path bytes to hex for comparison

### DIFF
--- a/pkg/snapshot/config.go
+++ b/pkg/snapshot/config.go
@@ -148,7 +148,8 @@ func (c *FileConfig) Init() error {
 
 func (c *ServiceConfig) Init() error {
 	viper.BindEnv(SNAPSHOT_ACCOUNTS_TOML, SNAPSHOT_ACCOUNTS)
-	allowedAccounts := viper.GetStringSlice(SNAPSHOT_ACCOUNTS)
+	var allowedAccounts []string
+	viper.UnmarshalKey(SNAPSHOT_ACCOUNTS_TOML, &allowedAccounts)
 	accountsLen := len(allowedAccounts)
 	if accountsLen != 0 {
 		c.AllowedAccounts = make(map[common.Address]struct{}, accountsLen)

--- a/pkg/snapshot/service.go
+++ b/pkg/snapshot/service.go
@@ -85,7 +85,7 @@ type SnapshotParams struct {
 func (s *Service) CreateSnapshot(params SnapshotParams) error {
 	paths := make([][]byte, 0, len(params.WatchedAddresses))
 	for addr := range params.WatchedAddresses {
-		paths = append(paths, crypto.Keccak256(addr.Bytes()))
+		paths = append(paths, keybytesToHex(crypto.Keccak256(addr.Bytes())))
 	}
 	s.watchingAddresses = len(paths) > 0
 	// extract header from lvldb and publish to PG-IPFS

--- a/pkg/snapshot/util.go
+++ b/pkg/snapshot/util.go
@@ -51,3 +51,15 @@ func decrementPath(path []byte) bool {
 	}
 	return true
 }
+
+// https://github.com/ethereum/go-ethereum/blob/master/trie/encoding.go#L97
+func keybytesToHex(str []byte) []byte {
+	l := len(str)*2 + 1
+	var nibbles = make([]byte, l)
+	for i, b := range str {
+		nibbles[i*2] = b / 16
+		nibbles[i*2+1] = b % 16
+	}
+	nibbles[l-1] = 16
+	return nibbles
+}


### PR DESCRIPTION
Fixes https://github.com/vulcanize/ipld-eth-state-snapshot/pull/46
- The iterator paths given by `it.Path()` are hex-encoded; the path bytes of a watched address has to be converted as such for valid comparison
- Fix for loading watched addresses from config