### PR TITLE
Fixes for account selective snapshot

### DIFF
--- a/pkg/snapshot/service.go
+++ b/pkg/snapshot/service.go
@@ -85,7 +85,7 @@ type SnapshotParams struct {
 func (s *Service) CreateSnapshot(params SnapshotParams) error {
 	paths := make([][]byte, 0, len(params.WatchedAddresses))
 	for addr := range params.WatchedAddresses {
-		paths = append(paths, crypto.Keccak256(addr.Bytes()))
+		paths = append(paths, keybytesToHex(crypto.Keccak256(addr.Bytes())))
 	}
 	s.watchingAddresses = len(paths) > 0
 	// extract header from lvldb and publish to PG-IPFS
@@ -171,7 +171,7 @@ type nodeResult struct {
 	elements []interface{}
 }
 
-func resolveNode(it trie.NodeIterator, trieDB *trie.Database) (*nodeResult, error) {
+func resolveNode(nodePath []byte, it trie.NodeIterator, trieDB *trie.Database) (*nodeResult, error) {
 	// "leaf" nodes are actually "value" nodes, whose parents are the actual leaves
 	if it.Leaf() {
 		return nil, nil
@@ -180,8 +180,8 @@ func resolveNode(it trie.NodeIterator, trieDB *trie.Database) (*nodeResult, erro
 		return nil, nil
 	}
 
-	path := make([]byte, len(it.Path()))
-	copy(path, it.Path())
+	path := make([]byte, len(nodePath))
+	copy(path, nodePath)
 	n, err := trieDB.Node(it.Hash())
 	if err != nil {
 		return nil, err
@@ -220,59 +220,91 @@ func (s *Service) createSnapshot(it trie.NodeIterator, headerID string, seekingP
 	}
 	defer func() { err = CommitOrRollback(tx, err) }()
 
+	// if path is nil
+	// 	(occurs before reaching state trie root)
+	// 	(when the iterator is created using tree.NodeIterator(nil))
+	// move on to next node (root)
+	if it.Path() == nil {
+		it.Next(true)
+		// process root node
+		// create snapshot of node, if it is a leaf this will also create snapshot of entire storage trie
+		if err := s.createNodeSnapshot(tx, it.Path(), it, headerID, seekingPaths); err != nil {
+			return err
+		}
+	}
+
 	// iterate all the nodes at this level
-	for it.Next(false) {
+	// if iterator is at an empty path (in case of root node or just before subtrie root in case of some concurrent iterators),
+	// descend in the first loop iteration to reach first child node
+	var descend bool
+	if bytes.Equal(it.Path(), []byte{}) {
+		descend = true
+	}
+	for it.Next(descend) {
+		// to avoid descending further
+		descend = false
+
 		// ignore node if it is not along paths of interest
 		if s.watchingAddresses && !validPath(it.Path(), seekingPaths) {
 			continue
 		}
+
 		// if the node is along paths of interest
 		// create snapshot of node, if it is a leaf this will also create snapshot of entire storage trie
-		if err := s.createNodeSnapshot(tx, it, headerID, seekingPaths); err != nil {
+		if err := s.createNodeSnapshot(tx, it.Path(), it, headerID, seekingPaths); err != nil {
 			return err
 		}
-		// create subTrie iterator for this node
-		subTrie, err := s.stateDB.OpenTrie(it.Hash())
-		if err != nil {
-			return err
-		}
-		subTrieIt := subTrie.NodeIterator(nil)
+
 		// traverse and process the next level of this subTrie
-		if err := s.createSubTrieSnapshot(tx, subTrieIt, headerID, seekingPaths); err != nil {
+		if err := s.createSubTrieSnapshot(tx, it.Path(), it.Hash(), headerID, seekingPaths); err != nil {
 			return err
 		}
 	}
+
 	return it.Error()
 }
 
-func (s *Service) createSubTrieSnapshot(tx Tx, it trie.NodeIterator, headerID string, seekingPaths [][]byte) error {
-	// iterate all the nodes at this level
-	for it.Next(false) {
+func (s *Service) createSubTrieSnapshot(tx Tx, prefixPath []byte, hash common.Hash, headerID string, seekingPaths [][]byte) error {
+	// create subTrie iterator for this node
+	subTrie, err := s.stateDB.OpenTrie(hash)
+	if err != nil {
+		return err
+	}
+	subTrieIt := subTrie.NodeIterator(nil)
+	// move on to the subtrie root node
+	// subtrie root node assumed to be already indexed at a higher level
+	subTrieIt.Next(true)
+
+	// descend in the first loop iteration to reach first child node
+	descend := true
+	for subTrieIt.Next(descend) {
+		// to avoid descending further
+		descend = false
+
+		// create the full node path as it.Path() doesn't include the path before subtrie root
+		nodePath := append(prefixPath, subTrieIt.Path()...)
 		// ignore node if it is not along paths of interest
-		if s.watchingAddresses && !validPath(it.Path(), seekingPaths) {
+		if s.watchingAddresses && !validPath(nodePath, seekingPaths) {
 			continue
 		}
+
 		// if the node is along paths of interest
 		// create snapshot of node, if it is a leaf this will also create snapshot of entire storage trie
-		if err := s.createNodeSnapshot(tx, it, headerID, seekingPaths); err != nil {
+		if err := s.createNodeSnapshot(tx, nodePath, subTrieIt, headerID, seekingPaths); err != nil {
 			return err
 		}
-		// create subTrie iterator for this node
-		subTrie, err := s.stateDB.OpenTrie(it.Hash())
-		if err != nil {
-			return err
-		}
-		subTrieIt := subTrie.NodeIterator(nil)
+
 		// traverse and process the next level of this subTrie
-		if err := s.createSubTrieSnapshot(tx, subTrieIt, headerID, seekingPaths); err != nil {
+		if err := s.createSubTrieSnapshot(tx, nodePath, subTrieIt.Hash(), headerID, seekingPaths); err != nil {
 			return err
 		}
 	}
-	return it.Error()
+
+	return subTrieIt.Error()
 }
 
-func (s *Service) createNodeSnapshot(tx Tx, it trie.NodeIterator, headerID string, seekingPaths [][]byte) error {
-	res, err := resolveNode(it, s.stateDB.TrieDB())
+func (s *Service) createNodeSnapshot(tx Tx, path []byte, it trie.NodeIterator, headerID string, seekingPaths [][]byte) error {
+	res, err := resolveNode(path, it, s.stateDB.TrieDB())
 	if err != nil {
 		return err
 	}
@@ -373,7 +405,7 @@ func (s *Service) storageSnapshot(sr common.Hash, headerID string, statePath []b
 
 	it := sTrie.NodeIterator(make([]byte, 0))
 	for it.Next(true) {
-		res, err := resolveNode(it, s.stateDB.TrieDB())
+		res, err := resolveNode(it.Path(), it, s.stateDB.TrieDB())
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fixes https://github.com/vulcanize/ipld-eth-state-snapshot/pull/46

* The iterator paths given by `it.Path()` are hex-encoded; the path bytes of a watched address has to be converted as such for valid comparison
* The `descend` flag needs to be passed as true to get to the first child of trie/subtrie being iterated; after which it can be passed as false to iterate over siblings instead of descending down further
* Use the full node path while processing a subtrie node
* Tested manually with a single and multiple (2, 4, 8, 16, 32) workers